### PR TITLE
New custom issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -1,0 +1,18 @@
+---
+name: Issue template
+about: This template is for user-submitted documentation requests.
+
+---
+
+# Request type
+- [ ] New documentation
+- [ ] Correction or update
+
+# Details
+*Please describe the document or change you are requesting.*
+
+## Page to change
+If this request relates to an existing article, please give its URL:
+
+## Related issues
+If this request relates to other issues in Bugzilla or GitHub, please provide links:

--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -8,11 +8,14 @@ about: This template is for user-submitted documentation requests.
 - [ ] New documentation
 - [ ] Correction or update
 
-# Details
-*Please describe the document or change you are requesting.*
-
 ## Page to change
 If this request relates to an existing article, please give its URL:
 
+
+# Details
+*Please describe the change you are requesting. If you know of technical experts who can review the change, please mention them.*
+
+
 ## Related issues
 If this request relates to other issues in Bugzilla or GitHub, please provide links:
+


### PR DESCRIPTION
Related to issue #295, this is a new custom template for user-submitted issues, to replace the [Documentation Request](https://bugzilla.mozilla.org/form.doc) form in Bugzilla. This is not an exact replacement, as it's not a form. 