### PR TITLE
Add option to make content issue triage easier

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -5,6 +5,7 @@ about: This template is for user-submitted documentation requests.
 ---
 
 # Request type
+- [x] Please close this issue, I accidentally submitted it without adding any details
 - [ ] New documentation
 - [ ] Correction or update
 


### PR DESCRIPTION
Many people submit a content issue without explaining the problem. This creates a staff burden to ask for follow-up details.  Make the default selection "Please close this issue", to encourage customization and make it easier to close issues without details.